### PR TITLE
Improve polar domains code

### DIFF
--- a/GuestHost/polardomains.py
+++ b/GuestHost/polardomains.py
@@ -176,7 +176,7 @@ def main():
     # Write OP to file
     if args.output_file:
         import csv
-        outfile = sys.argv[3]
+        outfile = args.outfile
         with open(outfile, "w") as f:
             wr = csv.writer(f, delimiter=" ")
             wr.writerows(OP)

--- a/GuestHost/polardomains.py
+++ b/GuestHost/polardomains.py
@@ -149,7 +149,7 @@ def main():
     parser.add_argument('--unit', choices=['radians', 'degrees'], default='degrees', help="The unit of the dihdral angles in the input file.")
     parser.add_argument('axis', type=int, choices=[0, 1, 2], help="The axis (0, 1, or 2) along which chains are chosen, usually the unique axis of the simulation.")
     parser.add_argument('output_file', nargs='?', type=str, help="The output filename to save the obtained persistence times (optional).")
-    parser.add_argument('--plot', type=int, help="Plot a histogram of persistence times for the specified domain size.")
+    parser.add_argument('--plot', type=int, metavar='DOMAIN_SIZE', help="Plot a histogram of persistence times for the specified domain size.")
 
     args = parser.parse_args()
 

--- a/GuestHost/polardomains.py
+++ b/GuestHost/polardomains.py
@@ -194,7 +194,7 @@ def main():
             print("Domain with {0:2d} sites is empty".format(i+1))
  
     if args.plot:
-        dsize = args.plot
+        dsize = (args.plot)-1
         plot_histogram(OP[dsize])
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use argparse to detect arguments/options. Added an option to specify unit of the dihedrals and a positional argument to optionally write the persistence times to an output file. Also, plotting histogram for each domain size can be specified by --plot option. Now if you do `python ./polardomains.py -h` we get the following help:
```
usage: polardomains.py [-h] [--unit {radians,degrees}] [--plot DOMAIN_SIZE] input_file {0,1,2} [output_file]

Obtain the persistence time for each domain sizes from the domains contained in the provided data.

positional arguments:
  input_file            The input filename containing the dihedrals in either radians or degrees.
  {0,1,2}               The axis (0, 1, or 2) along which chains are chosen, usually the unique axis of the simulation.
  output_file           The output filename to save the obtained persistence times (optional).

options:
  -h, --help            show this help message and exit
  --unit {radians,degrees}
                        The unit of the dihdral angles in the input file.
  --plot DOMAIN_SIZE    Plot a histogram of persistence times for the specified domain size.
```